### PR TITLE
Automate available dependency updates reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,27 @@ buildConfig([
       stage('Build and test Java project') {
         sh "mvn -s \$MAVEN_SETTINGS -B package"
       }
+
+      stage('Generate report for available updates') {
+        sh '''
+          mvn -s $MAVEN_SETTINGS -B -U \\
+            -Dversions.outputFile=dependency-updates.txt \\
+            versions:display-dependency-updates
+          mvn -s $MAVEN_SETTINGS -B -U \\
+            -Dversions.outputFile=plugin-updates.txt \\
+            versions:display-plugin-updates
+        '''
+
+        archiveArtifacts artifacts: 'dependency-updates.txt,plugin-updates.txt', fingerprint: true
+      }
+
+      stage('Show available updates') {
+        echo 'Available dependency updates'
+        sh 'cat dependency-updates.txt'
+
+        echo 'Available plugin updates:'
+        sh 'cat plugin-updates.txt'
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,14 +29,6 @@ buildConfig([
 
         archiveArtifacts artifacts: 'dependency-updates.txt,plugin-updates.txt', fingerprint: true
       }
-
-      stage('Show available updates') {
-        echo 'Available dependency updates'
-        sh 'cat dependency-updates.txt'
-
-        echo 'Available plugin updates:'
-        sh 'cat plugin-updates.txt'
-      }
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,19 @@
           </execution>
         </executions>
       </plugin>
+
+      <!--
+      Target versions for updates.
+      See https://confluence.capraconsulting.no/display/CALS/Keeping+dependencies+up-to-date
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <rulesUri>file:///${project.basedir}/versions-rules.xml</rulesUri>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- See https://stackoverflow.com/a/48715568 for details about this file -->
+<ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" comparisonMethod="maven" xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <!-- Ignore Alpha's, Beta's, release candidates and milestones -->
+    <ignoreVersion type="regex">(?i).*Alpha(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*a(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*Beta(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*-B(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*-eap(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*RC(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*CR(?:-?\d+)?</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*M(?:-?\d+)?</ignoreVersion>
+    <!-- Ignore org.postgresql:postgresql:42.2.5.jre7 and alike -->
+    <ignoreVersion type="regex">(?i).*jre\d+</ignoreVersion>
+  </ignoreVersions>
+  <rules>
+    <rule groupId="com.graphql-java" artifactId="graphql-java">
+      <ignoreVersions>
+        <!-- Avoid updates like 10.0 -> 2018-10-08T21-25-58-ac9d5c6 -->
+        <ignoreVersion type="regex">^\d\d\d\d-\d\d-\d\dT.*$</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
+</ruleset>

--- a/versions-rules.xml
+++ b/versions-rules.xml
@@ -14,12 +14,4 @@
     <!-- Ignore org.postgresql:postgresql:42.2.5.jre7 and alike -->
     <ignoreVersion type="regex">(?i).*jre\d+</ignoreVersion>
   </ignoreVersions>
-  <rules>
-    <rule groupId="com.graphql-java" artifactId="graphql-java">
-      <ignoreVersions>
-        <!-- Avoid updates like 10.0 -> 2018-10-08T21-25-58-ac9d5c6 -->
-        <ignoreVersion type="regex">^\d\d\d\d-\d\d-\d\dT.*$</ignoreVersion>
-      </ignoreVersions>
-    </rule>
-  </rules>
 </ruleset>


### PR DESCRIPTION
The important thing with this change is the addition of the rulefile to specify "allowed" updates.

Without this we would get something like this:

```
The following dependencies in Dependencies have newer versions:         
  ch.qos.logback:logback-classic ................. 1.2.3 -> 1.3.0-alpha4
  org.slf4j:jcl-over-slf4j ...................... 1.7.26 -> 2.0.0-alpha0
  org.slf4j:log4j-over-slf4j .................... 1.7.26 -> 2.0.0-alpha0
  org.slf4j:slf4j-api ........................... 1.7.26 -> 2.0.0-alpha0
  org.testng:testng .............................. 6.14.3 -> 7.0.0-beta4
```

In Jenkins two things change:

1) Archiving a file with report of the available changes

![image](https://user-images.githubusercontent.com/703354/59605369-eb042d80-910e-11e9-986b-7eb21d14f3d9.png)

2) The same reports are also printed to the build log duing the mvn commands

![image](https://user-images.githubusercontent.com/703354/59608551-d5463680-9115-11e9-8e51-eb200b8aa9b9.png)
